### PR TITLE
Allow version overrides

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -94,6 +94,66 @@ describe('Run', () => {
     expect(setFailed).not.toHaveBeenCalled()
   })
 
+  it('allows the version to be overriden', async () => {
+    const versionOverride = 'v1.0.1-beta.1'
+    // how do we mock `core.getInput` to return `versionOverride` if `default-branch` is the input?
+
+    const expectedChangelog = fs.readFileSync(
+      __dirname + '/expected-changelog.md',
+      'utf8'
+    )
+
+    nock('https://api.github.com')
+      .persist()
+      .get('/repos/foo/bar/releases')
+      .reply(200, successfulTagResponse)
+    nock('https://api.github.com')
+      .persist()
+      .get('/repos/foo/bar/compare/v1.0.0...master')
+      .reply(200, successfulComparisonResponse)
+    nock('https://api.github.com')
+      .persist()
+      .post('/repos/foo/bar/releases', {
+        tag_name: versionOverride,
+        name: versionOverride,
+        body: expectedChangelog
+      })
+      .reply(201, successfulComparisonResponse)
+
+    const setOutput = jest.spyOn(core, 'setOutput')
+    const infoMock = jest.spyOn(core, 'info')
+    const setFailed = jest.spyOn(core, 'setFailed')
+    await run()
+
+    expect(infoMock).toHaveBeenCalledWith('Listing releases for foo/bar')
+    expect(infoMock).toHaveBeenCalledWith(
+      'Comparing commits for foo/bar on v1.0.0 against master'
+    )
+    expect(infoMock).toHaveBeenCalledWith('master is behind by 4 commit(s)')
+    expect(infoMock).toHaveBeenCalledWith(
+      'latest release date is 2013-02-27T19:35:32Z'
+    )
+    expect(infoMock).toHaveBeenCalledWith(
+      `Creating release ${versionOverride} for foo/bar`
+    )
+    expect(setOutput).toHaveBeenCalledWith('commit-count', '4')
+    expect(setOutput).toHaveBeenCalledWith('new-version', versionOverride)
+    expect(setOutput).toHaveBeenCalledWith(
+      'release-url',
+      `https://github.com/foo/bar/releases/tag/${versionOverride}`
+    )
+    expect(setOutput).toHaveBeenCalledWith(
+      'diff-url',
+      `https://github.com/foo/bar/compare/v1.0.0...${versionOverride}`
+    )
+    expect(setOutput).toHaveBeenCalledWith(
+      'latest-release-date',
+      '2013-02-27T19:35:32Z'
+    )
+    expect(setOutput).toHaveBeenCalledWith('changelog', expectedChangelog)
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it('does not create a release if the github token env variable is not set', async () => {
     process.env.GITHUB_TOKEN = ''
     const errorMock = jest.spyOn(core, 'error')

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "What branch to compare releases against"
     required: false
     default: "master"
+  version-override:
+    description: "Is there a version that should be overridden?"
+    required: false
+    default: ""
 outputs:
   commit-count:
     description: How many commits are on in the new release

--- a/dist/index.js
+++ b/dist/index.js
@@ -1588,6 +1588,9 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
         const defaultBranch = core.getInput('default-branch', {
             required: false
         });
+        const versionOverride = core.getInput('version-override', {
+            required: false
+        });
         const githubToken = process.env['GITHUB_TOKEN'];
         if (!githubToken) {
             core.error("environment variable 'GITHUB_TOKEN' is not set");
@@ -1628,7 +1631,10 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
             return;
         }
         const newTag = semver.inc(latestRelease === null || latestRelease === void 0 ? void 0 : latestRelease.tag_name, 'patch');
-        const newVersion = `v${newTag}`;
+        let newVersion = `v${newTag}`;
+        if (versionOverride) {
+            newVersion = versionOverride;
+        }
         core.setOutput('new-version', newVersion);
         core.setOutput('release-url', `https://github.com/${owner}/${repo}/releases/tag/${newVersion}`);
         const compareUrl = `https://github.com/${owner}/${repo}/compare/${latestRelease.tag_name}...${newVersion}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,10 @@ const run = async (): Promise<void> => {
       required: false
     })
 
+    const versionOverride = core.getInput('version-override', {
+      required: false
+    })
+
     const githubToken = process.env['GITHUB_TOKEN']
     if (!githubToken) {
       core.error("environment variable 'GITHUB_TOKEN' is not set")
@@ -66,7 +70,10 @@ const run = async (): Promise<void> => {
     }
 
     const newTag = semver.inc(latestRelease?.tag_name, 'patch')
-    const newVersion = `v${newTag}`
+    let newVersion = `v${newTag}`
+    if (versionOverride) {
+      newVersion = versionOverride
+    }
     core.setOutput('new-version', newVersion)
     core.setOutput(
       'release-url',


### PR DESCRIPTION
In order to support Protos repo, we had a discussion to override version that create-release uses https://ecobeeteam.slack.com/archives/CN2MAUFDX/p1655142060349759?thread_ts=1655135584.275809&cid=CN2MAUFDX